### PR TITLE
Fixed log path to TheHiveHooks dir instead of the python3 call dir

### DIFF
--- a/thehive_hooks/__init__.py
+++ b/thehive_hooks/__init__.py
@@ -4,7 +4,9 @@ from logging.handlers import RotatingFileHandler
 from pyee import EventEmitter
 
 # Declare the logger
-handler = RotatingFileHandler('thehive-hooks.log', maxBytes=10000000, backupCount=1)
+app_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+pathLog = app_dir + '/thehive-hooks.log'
+handler = RotatingFileHandler(pathLog, maxBytes=10000000, backupCount=1)
 handler.setLevel(logging.INFO)
 handler.setFormatter(logging.Formatter(
     '[%(asctime)s] %(levelname)s in %(module)s: %(message)s'


### PR DESCRIPTION
Fixed log path to TheHiveHooks path instead of the python3 call path
Fix #2 