### PR TITLE
Adding missing import os to fix error on webhook

### DIFF
--- a/thehive_hooks/__init__.py
+++ b/thehive_hooks/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 import logging
 from logging.handlers import RotatingFileHandler
+import os
 from pyee import EventEmitter
 
 # Declare the logger


### PR DESCRIPTION
There is a missing import function for `os` which result in this error:

```
Traceback (most recent call last):
  File "/opt/TheHiveHooks/run.py", line 2, in <module>
    from thehive_hooks import app
  File "/opt/TheHiveHooks/thehive_hooks/__init__.py", line 7, in <module>
    app_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
NameError: name 'os' is not defined
```

By adding in the import, the web hook will run fine!